### PR TITLE
Return likelihoods from pairwise_kin_logl_ratios() + bugfixes

### DIFF
--- a/R/create_integer_genotype_matrix.R
+++ b/R/create_integer_genotype_matrix.R
@@ -45,6 +45,7 @@ create_integer_genotype_matrix <- function(LG, AF) {
     dplyr::mutate(GenoIdx = index_ab(a = `1`, b = `2`, A = NumA)) %>%  # get the genotype indexes
     dplyr::ungroup() %>%
     dplyr::select(Indiv, LocIdx, GenoIdx) %>%
+    tidyr::complete(Indiv, LocIdx = AF$LocIdx) %>% # add missing alles
     tidyr::spread(data = ., key = LocIdx, value = GenoIdx) # now spread it into a data frame that looks like the matrix we want
 
   # now, turn that into a base-0 integer matrix

--- a/R/find_close_matching_genotypes.R
+++ b/R/find_close_matching_genotypes.R
@@ -26,4 +26,6 @@ find_close_matching_genotypes <- function(LG, CK, max_mismatch) {
     dplyr::arrange(num_mismatch) %>%
     dplyr::mutate(indiv_1 = rownames(S)[ind1],
            indiv_2 = rownames(S)[ind2])
+
+  matchers
 }

--- a/src/pairwise_comps.cpp
+++ b/src/pairwise_comps.cpp
@@ -33,6 +33,7 @@ DataFrame comp_ind_pairwise(IntegerMatrix S, IntegerMatrix T, int t, NumericVect
   NumericVector val(nS);
   IntegerVector nonmiss(nS);  // for the number of non_missing loci
 
+  if(L != T.ncol()) stop("S and T must have same number of columns");
 
   for(i=0;i<nS;i++) {
     sum = 0.0;


### PR DESCRIPTION
Hi Eric,

Thank you for a very useful and and well-documented package!

This pull request has three changes, 

1.  Added missing return value for function `find_close_matching_genotypes()`, currently it only finds the matches, but does not return them.

2. A small change to `pairwise_kin_logl_ratios()` to optionally make it return the raw log likelihoods instead of ratios if the denominator is missing. 

3. I was using `pairwise_kin_logl_ratios()` to compare indivdiuals between years, and in some cases this made R crash and die. A little bit of debugging tracked this down to `create_integer_genotype_matrix()` and missing data in my dataaset: If a locus is missing from one of the set of compared individuals the correspondig column of the genotype matrix will also be missing. Having NAs in the input data set wouldn't help since the missing alleles are removed before the set is denormalised. The patch adds a `tidyr::complete()` statement to fill in the missing loci.

Regards,
Brage  Førland
Department of mathematics, University of Bergen


